### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,6 @@
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ezTxmMC/LuckPrefix/security/code-scanning/5](https://github.com/ezTxmMC/LuckPrefix/security/code-scanning/5)

To remediate the issue, you should add a `permissions` block with the least required privileges, preferably at the root of the workflow file so all jobs (present and future) restrict GITHUB_TOKEN permissions by default. For Go build and test workflows, the minimum necessary is `contents: read`, since no step requires writing to the repository, opening issues, or altering PRs. You should therefore insert:

```yaml
permissions:
  contents: read
```
directly after the workflow name, before the `on:` block in `.github/workflows/go.yml`. This ensures all jobs inherit this restricted permission, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
